### PR TITLE
Add line ending normalization

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     -   id: pycln
         args: [--all]
 -   repo: https://github.com/psf/black
-    rev: 22.1.0
+    rev: 22.3.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/isort


### PR DESCRIPTION
git registered files as modified due to line-ending conversions. Suggest to add `text=auto`in gitattributes to ensure that line-endings remains unaltered

From [git-doc](https://git-scm.com/docs/gitattributes)
> If you want to ensure that text files that any contributor introduces to the repository have their line endings normalized, you can set the text attribute to "auto" for all files.