### PR TITLE
Fix table functions

### DIFF
--- a/cimsparql/graphdb.py
+++ b/cimsparql/graphdb.py
@@ -80,11 +80,6 @@ class GraphDBClient:
             query += f" limit {limit}"
         return query
 
-    @staticmethod
-    def value_getter(d: Dict[str, str]) -> str:
-        """Get item of 'value' key if present else None"""
-        return d.get("value")
-
     def _exec_query(self, query: str, limit: Optional[int]):
         self.sparql.setQuery(self.query_with_header(query, limit))
 
@@ -92,7 +87,7 @@ class GraphDBClient:
 
         cols = processed_results["head"]["vars"]
         data = processed_results["results"]["bindings"]
-        out = [{c: self.value_getter(row.get(c, {})) for c in cols} for row in data]
+        out = [{c: row.get(c, {}).get("value") for c in cols} for row in data]
         return out, data_row(cols, data)
 
     def exec_query(self, query: str, limit: Optional[int] = None) -> List[Dict[str, str]]:

--- a/cimsparql/graphdb.py
+++ b/cimsparql/graphdb.py
@@ -99,7 +99,20 @@ class GraphDBClient:
         out, _ = self._exec_query(query, limit)
         return out
 
-    def _get_table(self, query: str, limit: Optional[int]) -> Tuple[pd.DataFrame, Dict[str, str]]:
+    def get_table(
+        self, query: str, limit: Optional[int] = None
+    ) -> Tuple[pd.DataFrame, Dict[str, str]]:
+        """
+        Args:
+           query: to sparql server
+           limit: limit number of resulting rows
+        Example:
+           >>> from cimsparql.graphdb import GraphDBClient
+           >>> from cimsparql.url import service
+           >>> gdbc = GraphDBClient(service('LATEST'))
+           >>> query = 'select * where { ?subject ?predicate ?object }'
+           >>> gdbc.get_table(query, limit=10)
+        """
         out, data_row = self._exec_query(query, limit)
         return pd.DataFrame(out), data_row
 
@@ -111,39 +124,6 @@ class GraphDBClient:
             return False
         except IndexError:
             return True
-
-    def get_table(
-        self,
-        query: str,
-        index: Optional[str] = None,
-        limit: Optional[int] = None,
-    ) -> pd.DataFrame:
-        """Gets given table from the configured database.
-
-        Args:
-           query: to sparql server
-           index: column name to use as index
-           limit: limit number of resulting rows
-           map_data_types: gets datatypes from the configured graphdb & maps the types in the result
-                  to correct python types
-           custom_maps: dictionary of 'sparql_datatype': function to apply on columns with that
-                  type. Overwrites sparql map for the types specified.
-           columns: dictionary of 'column_name': function,
-                  uses pandas astype on the column, or applies function.
-                  Sparql map overwrites columns when available
-
-        Example:
-           >>> from cimsparql.graphdb import GraphDBClient
-           >>> from cimsparql.url import service
-           >>> gdbc = GraphDBClient(service('LATEST'))
-           >>> query = 'select * where { ?subject ?predicate ?object }'
-           >>> gdbc.get_table(query, limit=10)
-        """
-        try:
-            result, data_row = self._get_table(query, limit)
-        except IndexError:
-            return pd.DataFrame([]), {}
-        return result, data_row
 
     def get_prefixes(self) -> Dict[str, str]:
         prefixes = {}

--- a/cimsparql/graphdb.py
+++ b/cimsparql/graphdb.py
@@ -120,7 +120,7 @@ class GraphDBClient:
     def empty(self) -> bool:
         """Identify empty GraphDB repo"""
         try:
-            self._get_table("SELECT * \n WHERE { ?s ?p ?o }", limit=1)
+            self.get_table("SELECT * \n WHERE { ?s ?p ?o }", limit=1)
             return False
         except IndexError:
             return True

--- a/cimsparql/model.py
+++ b/cimsparql/model.py
@@ -80,14 +80,14 @@ class Model:
         pref = self.client.prefixes.prefixes
         return "cim" in pref and self.mapper.have_cim_version(pref["cim"])
 
-    def _get_table_and_convert(
+    def get_table_and_convert(
         self,
         query: str,
         limit: Optional[int] = None,
         index: Optional[str] = None,
         columns: Optional[Dict[str, str]] = None,
     ) -> pd.DataFrame:
-        result, data_row = self.client.get_table(query, index, limit)
+        result, data_row = self.client.get_table(query, limit)
 
         if self.mapper is not None:
             col_map = self.col_map(data_row, columns)
@@ -95,7 +95,6 @@ class Model:
 
         if index and not result.empty:
             result.set_index(index, inplace=True)
-
         return result
 
 
@@ -115,7 +114,7 @@ class CimModel(Model):
         """Activation date for this repository"""
         if self._date_version:
             return self._date_version
-        repository_date = self._get_table_and_convert(queries.version_date())
+        repository_date = self.get_table_and_convert(queries.version_date())
         self._date_version = repository_date["activationDate"].values[0]
         if isinstance(self._date_version, np.datetime64):
             self._date_version = self._date_version.astype("<M8[s]").astype(datetime)
@@ -125,7 +124,7 @@ class CimModel(Model):
         query = queries.full_model()
         if dry_run:
             return self.client.query_with_header(query)
-        return self._get_table_and_convert(query)
+        return self.get_table_and_convert(query)
 
     def bus_data(
         self,
@@ -153,7 +152,7 @@ class CimModel(Model):
             )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def phase_tap_changers(
         self,
@@ -171,7 +170,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def loads(
         self,
@@ -230,7 +229,7 @@ class CimModel(Model):
         if dry_run:
             return self.client.query_with_header(query, limit)
 
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def wind_generating_units(
         self,
@@ -259,7 +258,7 @@ class CimModel(Model):
         query = queries.wind_generating_unit_query(network_analysis)
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def synchronous_machines(
         self,
@@ -311,7 +310,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def connections(
         self,
@@ -347,7 +346,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def borders(
         self,
@@ -383,7 +382,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def converters(
         self,
@@ -399,7 +398,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query)
-        return self._get_table_and_convert(query, index="mrid")
+        return self.get_table_and_convert(query, index="mrid")
 
     def transformers_connected_to_converter(
         self,
@@ -422,7 +421,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query)
-        return self._get_table_and_convert(query, index="converter_mrid")
+        return self.get_table_and_convert(query, index="converter_mrid")
 
     def ac_lines(
         self,
@@ -475,7 +474,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        ac_lines = self._get_table_and_convert(query, limit=limit)
+        ac_lines = self.get_table_and_convert(query, limit=limit)
         if temperatures is not None:
             for temperature in temperatures:
                 column = f"{sup.negpos(temperature)}_{abs(temperature)}_factor"
@@ -527,7 +526,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit=limit)
+        return self.get_table_and_convert(query, limit=limit)
 
     def transformers(
         self,
@@ -565,7 +564,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit=limit)
+        return self.get_table_and_convert(query, limit=limit)
 
     def two_winding_transformers(
         self,
@@ -615,7 +614,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit=limit)
+        return self.get_table_and_convert(query, limit=limit)
 
     def three_winding_transformers(
         self,
@@ -665,7 +664,7 @@ class CimModel(Model):
         )
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit=limit)
+        return self.get_table_and_convert(query, limit=limit)
 
     def disconnected(
         self, index: Optional[str] = None, limit: Optional[int] = None, dry_run: bool = False
@@ -694,7 +693,7 @@ class CimModel(Model):
         query = ssh_queries.synchronous_machines()
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def ssh_load(
         self,
@@ -715,7 +714,7 @@ class CimModel(Model):
         query = ssh_queries.load(rdf_types)
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def ssh_generating_unit(
         self,
@@ -737,7 +736,7 @@ class CimModel(Model):
         query = ssh_queries.generating_unit(rdf_types)
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def terminal(
         self, limit: Optional[int] = None, dry_run: bool = False
@@ -751,7 +750,7 @@ class CimModel(Model):
         query = tp_queries.terminal(self.cim_version)
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def topological_node(
         self, limit: Optional[int] = None, dry_run: bool = False
@@ -765,7 +764,7 @@ class CimModel(Model):
         query = tp_queries.topological_node()
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def powerflow(
         self,
@@ -783,7 +782,7 @@ class CimModel(Model):
         query = sv_queries.powerflow(power)
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def voltage(
         self,
@@ -801,7 +800,7 @@ class CimModel(Model):
         query = sv_queries.voltage(voltage_vars)
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     def tapstep(
         self, limit: Optional[int] = None, dry_run: bool = False
@@ -815,7 +814,7 @@ class CimModel(Model):
         query = sv_queries.tapstep()
         if dry_run:
             return self.client.query_with_header(query, limit)
-        return self._get_table_and_convert(query, limit, index="mrid")
+        return self.get_table_and_convert(query, limit, index="mrid")
 
     @property
     def regions(self) -> pd.DataFrame:
@@ -831,7 +830,7 @@ class CimModel(Model):
             >>> model.regions
         """
         query = queries.regions_query()
-        return self._get_table_and_convert(query, limit=None, index="mrid")
+        return self.get_table_and_convert(query, limit=None, index="mrid")
 
 
 def get_cim_model(

--- a/cimsparql/model.py
+++ b/cimsparql/model.py
@@ -80,21 +80,6 @@ class Model:
         pref = self.client.prefixes.prefixes
         return "cim" in pref and self.mapper.have_cim_version(pref["cim"])
 
-    @classmethod
-    def _manual_convert_types(
-        cls, df: pd.DataFrame, columns: Optional[Dict], index: Optional[str]
-    ) -> pd.DataFrame:
-        if columns is None:
-            columns = {}
-        reset_index = index is not None
-        if reset_index:
-            df.reset_index(inplace=True)
-        df = df.astype(str)
-        cls._assign_column_types(df, columns)
-        if reset_index:
-            df.set_index(index, inplace=True)
-        return df
-
     def _get_table_and_convert(
         self,
         query: str,
@@ -110,9 +95,6 @@ class Model:
 
         if index and not result.empty:
             result.set_index(index, inplace=True)
-
-        if not self.map_data_types and len(result) > 0:
-            result = self._manual_convert_types(result, columns, index)
 
         return result
 

--- a/tests/test_graphdb.py
+++ b/tests/test_graphdb.py
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.skipif(os.getenv("GRAPHDB_API", None) is None, reason="Need graphdb server to run")
-@patch.object(CimModel, "_get_table_and_convert")
+@patch.object(CimModel, "get_table_and_convert")
 def test_date_version(get_table_mock, cim_model: CimModel):
     t_ref = datetime(2020, 1, 1)
     get_table_mock.return_value = pd.DataFrame(

--- a/tests/test_rdf4j.py
+++ b/tests/test_rdf4j.py
@@ -45,3 +45,11 @@ def test_upload_rdf_xml(rdf4j_gdb):
 
     df = rdf4j_gdb.exec_query("SELECT * WHERE {?s rdf:type md:FullModel}")
     assert len(df) == 1
+
+
+def test_get_table_default_arg(rdf4j_gdb):
+    if skip_rdf4j_test(rdf4j_gdb):
+        pytest.skip("Require access to RDF4J service")
+
+    df = rdf4j_gdb.get_table("SELECT * {?s ?o ?p}")[0]
+    assert len(df) == 6


### PR DESCRIPTION
Changes

* Remove the concept `manual_convert`. We should never perform conversions outside `TypeMapper`. If we need to add specific conversions that can not be inferred from GraphDB, they should be passed via `custom_additions` argument when the `TypeMapper` is constructed
* We no longer have both `_get_table` and `get_table`. Now we just have one `get_table`
* Make `get_table_and_convert` "public"