### PR TITLE
Add template based query for transformers_connected_to_converter

### DIFF
--- a/cimsparql/query_support.py
+++ b/cimsparql/query_support.py
@@ -1,3 +1,4 @@
+import re
 from typing import Dict, Iterable, List, Literal, Optional, Union
 
 from cimsparql.cim import (
@@ -276,3 +277,15 @@ def border_filter(region: Union[str, List[str]], area1: str, area2: str) -> List
         combine_statements(*_in_first(area1, area2, regions)),
         combine_statements(*_in_first(area2, area1, regions)),
     ]
+
+
+def insert_params(template: str, params: Dict[str, str]) -> str:
+    query = template[:]  # Make sure we modify a copy of the template
+    for param, value in params.items():
+        query = query.replace(f"{{{{{param}}}}}", value)
+
+    # Remove remaining placeholders
+    matches = re.findall(r"({{\w+}})", query)
+    for match in matches:
+        query = query.replace(match, "")
+    return query.strip()

--- a/tests/test_graphdb.py
+++ b/tests/test_graphdb.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from datetime import datetime
-from typing import List
+from typing import List, Union
 from unittest.mock import patch
 
 import numpy as np
@@ -237,8 +237,9 @@ def test_transformer_connected_to_dc_converters(cim_model: CimModel):
 
 
 @pytest.mark.skipif(os.getenv("GRAPHDB_API", None) is None, reason="Need graphdb server to run")
-def test_transformer_connected_to_converters(cim_model: CimModel):
-    transformers = cim_model.transformers_connected_to_converter(region="NO")
+@pytest.mark.parametrize("region", ["NO", ["NO", "NON-EXISTING"]])
+def test_transformer_connected_to_converters(cim_model: CimModel, region: Union[str, List[str]]):
+    transformers = cim_model.transformers_connected_to_converter(region=region)
     assert set(transformers.columns) == {"t_mrid", "name", "mrid"}
     assert len(transformers) == 26
 


### PR DESCRIPTION
This is a suggestion we may consider in order to improve the readability of the code. 

**Background**

Parts of the `cimsparql` code contains pieces for building queries. It is done via functions such as `combine_statements`, `common_subjects?` etc. In several cases (perhaps the majority??) those functions are simply used to construct constant parts of queries. The benefit of those functions is that they enables construction of queries at runtime, but the downside is that the queries in the code looks very different from what one would see in a SparQL editor. Which in turns makes it difficult to understand what the resulting query will look like just by reading the code. I believe we could improve the readability of the code buy swithing to constructing queries from `templates`. E.g. there are template that constructs all the static parts of the queries with placeholders for the dynamic parts.

**Example**: `transformers_connected_to_converter`

Current version
```python
def transformers_connected_to_converter(
    region: Region, sub_region: bool, converter_types: Iterable[ConverterTypes]
) -> str:
    mrid_subject = "?_mrid"
    name = "?name"
    variables = ["?mrid", "?t_mrid", "?converter_mrid", name]
    converters = [sup.rdf_type_tripler("?volt", converter) for converter in converter_types]
    where_list = [
        f"?volt {ID_OBJ}.mRID ?converter_mrid",
        f"{mrid_subject} {ID_OBJ}.mRID ?mrid",
        f"?_t_mrid {ID_OBJ}.mRID ?t_mrid",
        sup.rdf_type_tripler(mrid_subject, "cim:PowerTransformer"),
        sup.get_name(mrid_subject, name, alias=True),
        f"?_t_mrid {TC_EQUIPMENT} {mrid_subject}",
        f"?_t_mrid {TC_NODE}/^{TC_NODE}/{TC_EQUIPMENT} ?volt",
        sup.combine_statements(*converters, group=len(converters) > 1, split=union_split),
    ]
    if region:
        where_list.append(f"{mrid_subject} {EQUIP_CONTAINER} ?Substation")
        where_list.extend(sup.region_query(region, sub_region, "Substation"))
    return sup.combine_statements(sup.select_statement(variables), sup.group_query(where_list))
```

If we base the code on templates it could look like this

```python
TRANSF_CON_TO_CONVERTER = f"""
SELECT ?mrid ?t_mrid ?converter_mrid ?name WHERE {{
    ?volt {ID_OBJ}.mRID ?converter_mrid.
    ?_mrid {ID_OBJ}.mRID ?mrid.
    ?_t_mrid {ID_OBJ}.mRID ?t_mrid.
    ?_mrid rdf:type cim:PowerTransformer.
    ?_mrid {ID_OBJ}.aliasName ?name.
    ?_t_mrid {TC_EQUIPMENT} ?_mrid.
    ?_t_mrid {TC_NODE}/^{TC_NODE}/{TC_EQUIPMENT} ?volt.
    {{{{converters}}}}.
    {{{{region}}}}
}}
"""

TRANSF_REG = f"""
    ?_mrid {EQUIP_CONTAINER} ?Substation .
    ?Substation cim:Substation.Region ?subgeoreg.
    ?subgeoreg {{{{subst_predicate}}}} ?area FILTER regex(?area, '{{{{regions}}}}')
"""


def transformers_connected_to_converter(
    region: Region, sub_region: bool, converter_types: Iterable[ConverterTypes]
) -> str:
    converters = [sup.rdf_type_tripler("?volt", converter) for converter in converter_types]
    cnv_query = sup.combine_statements(*converters, group=len(converters) > 1, split=union_split)
    params = {"converters": cnv_query}

    if region:
        params["region"] = populate_transf_reg(sub_region, region)
    return insert_params(TRANSF_CON_TO_CONVERTER, params)


def populate_transf_reg(sub_region: bool, region: Region) -> str:
    predicate = "SN:IdentifiedObject.shortName" if sub_region else f"{GEO_REG}.Region/{ID_OBJ}.name"
    params = {
        "subst_predicate": predicate,
        "regions": region if isinstance(region, str) else "|".join(region),
    }
    return insert_params(TRANSF_REG, params)
```

where the templates are stored as global constants. The dynamic parts of a query is enclosed by double curly brackets.

**Benefits**
* Shorter code since the actual python code only has to deal with the dynamic parts of all queries
* It is (at least in my opinion) easier to see how the final query will be, since the template is formatted very similar to what one would see in a SPARQL editor
* Easier to test subqueries. In this case adding `region` is optional. But the part requesting regions can by tested individually by enclosing `TRANS_REG` template by `SELECT * WHERE` which can be done in a unit test.

If we choose to switch to template based queries, it is something that can be gradually introduced without making API breaking changes (e.g. we can merge one function at the time)