### PR TITLE
Fix query for terminal active flow

### DIFF
--- a/cimsparql/sparql/dc_active_power_flow.sparql
+++ b/cimsparql/sparql/dc_active_power_flow.sparql
@@ -11,7 +11,7 @@ where {
              cim:Equipment.EquipmentContainer/cim:Line.Region ?_region .
       ?_t_mrid rdf:type cim:Terminal;
                cim:Terminal.ConductingEquipment ?_mrid;
-               cim:ACDCTerminal.sequenceNumber ?nr .
+               cim:Terminal.sequenceNumber|cim:ACDCTerminal.sequenceNumber ?nr .
       service <${repo}> {?_t_mrid ^cim:SvPowerFlow.Terminal/cim:SvPowerFlow.p ?p}
     }
   }

--- a/cimsparql/sparql/dc_active_power_flow.sparql
+++ b/cimsparql/sparql/dc_active_power_flow.sparql
@@ -8,7 +8,7 @@ where {
     where {
       values ?rdf_type {cim:ACLineSegment cim:SeriesCompensator} .
       ?_mrid rdf:type ?rdf_type;
-             cim:Equipment.EquipmentContainer/cim:Line.Region ?_region .
+             cim:Equipment.EquipmentContainer/(cim:Line.Region|cim:VoltageLevel.Substation/cim:Substation.Region) ?_region .
       ?_t_mrid rdf:type cim:Terminal;
                cim:Terminal.ConductingEquipment ?_mrid;
                cim:Terminal.sequenceNumber|cim:ACDCTerminal.sequenceNumber ?nr .


### PR DESCRIPTION
Must use cim:VoltageLevel.Substation for cim:SeriesCompensators when locating the region.