### PR TITLE
Three winding transformers: handle more than three windings

### DIFF
--- a/cimsparql/sparql/three_winding.sparql
+++ b/cimsparql/sparql/three_winding.sparql
@@ -44,7 +44,7 @@ where {
       ?p_transformer ^cim:PowerTransformerEnd.PowerTransformer/cim:TransformerEnd.endNumber ?nr
     }
     group by ?p_transformer
-    having (?winding_count = 3)
+    having (?winding_count > 2)
   } .
 
   # Optionally extract active power limits

--- a/cimsparql/sparql/three_winding_dummy_nodes.sparql
+++ b/cimsparql/sparql/three_winding_dummy_nodes.sparql
@@ -14,7 +14,7 @@ where
       filter(regex(?area, '${region}'))
     }
     group by ?p_transformer
-    having (?winding_count = 3)
+    having (?winding_count > 2)
   } .
   ?p_transformer cim:IdentifiedObject.mRID ?node;
            cim:IdentifiedObject.name ?name;

--- a/cimsparql/sparql/three_winding_loss.sparql
+++ b/cimsparql/sparql/three_winding_loss.sparql
@@ -17,7 +17,7 @@ where {
       ?p_transformer ^cim:PowerTransformerEnd.PowerTransformer/cim:TransformerEnd.endNumber ?nr .
     }
     group by ?p_transformer
-    having (?winding_count = 3)
+    having (?winding_count > 2)
   }
   { select ?p_transformer (sum(xsd:double(str(?sv_p))) / sum(?in_service) as ?ploss_2)
     where


### PR DESCRIPTION
Any n-winding transformer where n > 2 can be handled the same way as a three-winding transformer.