### PR TITLE
Bugfix b9cda59

### DIFF
--- a/cimsparql/async_sparql_wrapper.py
+++ b/cimsparql/async_sparql_wrapper.py
@@ -32,7 +32,7 @@ class AsyncSparqlWrapper(SPARQLWrapper):
         url = request.get_full_url()
         method = request.get_method()
 
-        args = {"timeout": self.timeout} | {"verify": self.ca_bundle} if self.ca_bundle else {}
+        args = {"timeout": self.timeout} | ({"verify": self.ca_bundle} if self.ca_bundle else {})
         async with httpx.AsyncClient(**args) as client:
             response = await client.request(
                 method, url, headers=request.headers, content=request.data


### PR DESCRIPTION
In the original commit "timeout" was stripped whenever
bool(self.ca_bundle) was False, as "|" is evaluated before "if"
setting args to {}.