### PR TITLE
fix: devide controller factor by number of poles for any converter

### DIFF
--- a/cimsparql/sparql/converters.sparql
+++ b/cimsparql/sparql/converters.sparql
@@ -14,8 +14,14 @@ where {
                   cim:IdentifiedObject.name ?name;
 		  ALG:VoltageSourceConverter.DCPole|ALG:DCConverter.DCPole ?pole.
 
-        ?pole ALG:DCPole.DCController/cim:IdentifiedObject.mRID ?controller;
-              ALG:DCPole.participationFactor ?controller_factor.
+        ?pole ALG:DCPole.DCController/cim:IdentifiedObject.mRID ?controller.
+	{
+	  select ?pole (max(xsd:float(str(?controller_factor))) / count(*) as ?controller_factor)
+	  {
+	    ?converter ALG:VoltageSourceConverter.DCPole|ALG:DCConverter.DCPole ?pole.
+            ?pole ALG:DCPole.participationFactor ?controller_factor.
+	  } group by ?pole
+	}
 
         optional {?converter cim:IdentifiedObject.aliasName ?alias .}
         # Extract properties for the terminals for the converter


### PR DESCRIPTION
The controller factor is given per pole and there can be one or two converters per pole.