### PR TITLE
refactor: drop all power transformers in ras equipment query

### DIFF
--- a/src/cimsparql/sparql/ras_equipment.sparql
+++ b/src/cimsparql/sparql/ras_equipment.sparql
@@ -3,7 +3,6 @@ PREFIX cim: <http://iec.ch/TC57/2013/CIM-schema-cim16#>
 PREFIX alg: <http://www.alstom.com/grid/CIM-schema-cim15-extension#>
 PREFIX SN: <http://www.statnett.no/CIM-schema-cim15-extension#>
 SELECT ?mrid ?equipment_mrid ?name ?flip ?collection WHERE {
-  VALUES ?equipment_type { cim:Breaker cim:ACLineSegment cim:PowerTransformerEnd cim:Disconnector cim:NonConformLoad cim:SynchronousMachine cim:ConformLoad cim:StaticVarCompensator alg:DCController cim:EnergyConsumer }
   [] (alg:ProtectiveActionEquipment.Equipment | alg:ProtectiveActionAdjustmentAC.ConductingEquipment | alg:ProtectiveActionAdjustmentDCController.DCController | SN:ProtectiveActionEquipment.TransformerEnd) ?equipment ;
      cim:IdentifiedObject.mRID ?mrid ;
      cim:IdentifiedObject.name ?name ;
@@ -21,4 +20,5 @@ SELECT ?mrid ?equipment_mrid ?name ?flip ?collection WHERE {
   }
   # Support both typed flow_shift and untyped
   BIND (BOUND(?is_branch) && (((STR(?flow_shift) = "true") && (STR(?flow_shift_flip) = "true")) || (STR(?load_contribution) = "true")) AS ?flip)
+  FILTER (?equipment_type != cim:PowerTransformer)
 }


### PR DESCRIPTION
It is better to drop the one we do not want.